### PR TITLE
Add minimumFractionDigits to fix exception

### DIFF
--- a/util/format-dollars.js
+++ b/util/format-dollars.js
@@ -10,6 +10,7 @@ module.exports = function formatDollars(amount, {cents = true} = {}) {
 	return parseFloat(amount).toLocaleString('en-US', {
 		style: 'currency',
 		currency: 'USD',
+		minimumFractionDigits: 0,
 		maximumFractionDigits: cents ? 2 : 0
 	});
 };


### PR DESCRIPTION
The default value of minimumFractionDigits is 2, if maximumFractionDigits is < minimumFractionDigits (in this case when `cents` is false), an error occurs.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString for the parameters and a link to the ISO specification for default value for USD.
See: https://stackoverflow.com/questions/41045270/range-error-with-tolocalestring-with-maximumnumber-of-digits-0 for someone else running into issues.